### PR TITLE
Creating an integration layer to integrate with oracle-query-api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.bankruptofficersearch.api.exception;
+
+import static uk.gov.companieshouse.bankruptofficersearch.api.BankruptOfficerSearchApiApplication.APPLICATION_NAME_SPACE;
+
+import java.util.HashMap;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception ex) {
+
+        HashMap<String, Object> message = new HashMap<>();
+        message.put("message", ex.getMessage());
+        message.put("error", ex.getClass());
+        LOGGER.error(ex.getMessage(), message);
+        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/BankruptOfficerDao.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/BankruptOfficerDao.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.bankruptofficersearch.api.request;
+
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
+
+public interface BankruptOfficerDao {
+
+    ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(ScottishBankruptOfficerSearchEntity search);
+
+    ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(String officerId);
+}

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.bankruptofficersearch.api.request;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
+
+@Component
+public class OracleQueryDaoImpl implements BankruptOfficerDao {
+
+    private static final String OFFICERS_URI = "/officer-search/scottish-bankrupt-officers";
+
+    private static final UriTemplate OFFICER_URI = new UriTemplate(OFFICERS_URI + "/{officerId}");
+
+    private RestTemplate restTemplate;
+
+    @Value("${ORACLE_QUERY_API_URL}")
+    private String oracleQueryApiUrl;
+
+    @Autowired
+    public OracleQueryDaoImpl(final RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(final ScottishBankruptOfficerSearchEntity search) {
+
+        return restTemplate.postForObject(oracleQueryApiUrl + OFFICERS_URI, search,
+            ScottishBankruptOfficerSearchResultsEntity.class);
+    }
+
+    @Override
+    public ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(final String officerId) {
+        String uri = OFFICER_URI.expand(officerId).toString();
+
+        return restTemplate.getForObject(oracleQueryApiUrl + uri, ScottishBankruptOfficerDetailsEntity.class);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -3,18 +3,19 @@ package uk.gov.companieshouse.bankruptofficersearch.api.exception;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-@ExtendWith(MockitoExtension.class)
 public class GlobalExceptionHandlerTest {
 
-    @InjectMocks
     private GlobalExceptionHandler globalExceptionHandler;
+
+    @BeforeEach
+    void setUp() {
+        this.globalExceptionHandler = new GlobalExceptionHandler();
+    }
 
     @Test
     void testHandleException() {

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -19,7 +19,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void testHandleException() {
-        ResponseEntity entity = globalExceptionHandler.handleException(new Exception());
+        ResponseEntity<Object> entity = globalExceptionHandler.handleException(new Exception());
 
         assertNotNull(entity);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,entity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public class GlobalExceptionHandlerTest {
+class GlobalExceptionHandlerTest {
 
     private GlobalExceptionHandler globalExceptionHandler;
 

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.bankruptofficersearch.api.exception;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.bankruptofficersearch.api.exception;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class GlobalExceptionHandlerTest {
+
+    @InjectMocks
+    private GlobalExceptionHandler globalExceptionHandler;
+
+    @Test
+    void testHandleException() {
+        ResponseEntity entity = globalExceptionHandler.handleException(new Exception());
+
+        assertNotNull(entity);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,entity.getStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
@@ -16,7 +16,7 @@ import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBa
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
 
 @ExtendWith(MockitoExtension.class)
-public class OracleQueryDaoImplTest {
+class OracleQueryDaoImplTest {
 
     private static final String ORACLE_QUERY_API_TEST_URL = "http://oracle-query-api";
 

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
@@ -1,0 +1,135 @@
+package uk.gov.companieshouse.bankruptofficersearch.api.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class OracleQueryDaoImplTest {
+
+    private static final String ORACLE_QUERY_API_TEST_URL = "http://oracle-query-api";
+
+    private static final String OFFICERS_URI = "/officer-search/scottish-bankrupt-officers";
+
+    private static final String OFFICER_ID = "1234567890";
+
+    private static final String FORENAME_1 = "forename1";
+    private static final String FORENAME_2 = "forename2";
+    private static final String ALIAS = "alias";
+    private static final String SURNAME = "surname";
+    private static final String ADDRESS_LINE_1 = "addressLine1";
+    private static final String ADDRESS_LINE_2 = "addressLine2";
+    private static final String ADDRESS_LINE_3 = "addressLine3";
+    private static final String TOWN = "town";
+    private static final String COUNTY = "county";
+    private static final String POSTCODE = "postcode";
+    private static final LocalDate DATE_OF_BIRTH = LocalDate.now();
+    private static final String CASE_REFERENCE = "caseReference";
+    private static final String CASE_TYPE = "caseType";
+    private static final String BANKRUPTCY_TYPE = "bankruptcyType";
+    private static final LocalDate START_DATE = LocalDate.now();
+    private static final LocalDate DEBTOR_DISCHARGE_DATE = LocalDate.now();
+    private static final LocalDate TRUSTEE_DISCHARGE_DATE = LocalDate.now();
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private ScottishBankruptOfficerSearchEntity searchEntity;
+
+    @InjectMocks
+    private OracleQueryDaoImpl oracleQueryDao;
+
+    @BeforeEach
+    public void setup() {
+        ReflectionTestUtils.setField(oracleQueryDao, "oracleQueryApiUrl", ORACLE_QUERY_API_TEST_URL);
+    }
+
+    @Test
+    public void testGetScottishBankruptOfficers() {
+        ScottishBankruptOfficerSearchResultsEntity searchResults = createSearchResults();
+
+        when(restTemplate.postForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI, searchEntity, ScottishBankruptOfficerSearchResultsEntity.class)).thenReturn(searchResults);
+
+        ScottishBankruptOfficerSearchResultsEntity result = oracleQueryDao.getScottishBankruptOfficers(searchEntity);
+
+        assertEquals(searchResults, result);
+    }
+
+    @Test
+    public void testGetScottishBankruptOfficer() {
+        ScottishBankruptOfficerDetailsEntity expected = createScottishBankruptOfficer();
+
+        when(restTemplate.getForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI + "/" + OFFICER_ID, ScottishBankruptOfficerDetailsEntity.class)).thenReturn(expected);
+
+        ScottishBankruptOfficerDetailsEntity result = oracleQueryDao.getScottishBankruptOfficer(OFFICER_ID);
+
+        assertEquals(expected, result);
+    }
+
+    private ScottishBankruptOfficerDetailsEntity createScottishBankruptOfficer() {
+        ScottishBankruptOfficerDetailsEntity detailsEntity = new ScottishBankruptOfficerDetailsEntity();
+        detailsEntity.setEphemeralKey(OFFICER_ID);
+        detailsEntity.setForename1(FORENAME_1);
+        detailsEntity.setForename2(FORENAME_2);
+        detailsEntity.setAlias(ALIAS);
+        detailsEntity.setSurname(SURNAME);
+        detailsEntity.setAddressLine1(ADDRESS_LINE_1);
+        detailsEntity.setAddressLine2(ADDRESS_LINE_2);
+        detailsEntity.setAddressLine3(ADDRESS_LINE_3);
+        detailsEntity.setTown(TOWN);
+        detailsEntity.setCounty(COUNTY);
+        detailsEntity.setPostcode(POSTCODE);
+        detailsEntity.setDateOfBirth(DATE_OF_BIRTH);
+        detailsEntity.setCaseReference(CASE_REFERENCE);
+        detailsEntity.setCaseType(CASE_TYPE);
+        detailsEntity.setBankruptcyType(BANKRUPTCY_TYPE);
+        detailsEntity.setStartDate(START_DATE);
+        detailsEntity.setDebtorDischargeDate(DEBTOR_DISCHARGE_DATE);
+        detailsEntity.setTrusteeDischargeDate(TRUSTEE_DISCHARGE_DATE);
+
+        return detailsEntity;
+    }
+
+    private ScottishBankruptOfficerSearchResultsEntity createSearchResults() {
+
+        ScottishBankruptOfficerSearchResultEntity resultEntity = new ScottishBankruptOfficerSearchResultEntity();
+        resultEntity.setEphemeralKey(OFFICER_ID);
+        resultEntity.setForename1(FORENAME_1);
+        resultEntity.setForename2(FORENAME_2);
+        resultEntity.setSurname(SURNAME);
+        resultEntity.setAddressLine1(ADDRESS_LINE_1);
+        resultEntity.setAddressLine2(ADDRESS_LINE_2);
+        resultEntity.setAddressLine3(ADDRESS_LINE_3);
+        resultEntity.setTown(TOWN);
+        resultEntity.setCounty(COUNTY);
+        resultEntity.setPostcode(POSTCODE);
+        resultEntity.setDateOfBirth(DATE_OF_BIRTH);
+
+        List<ScottishBankruptOfficerSearchResultEntity> scottishBankruptOfficerResultList = new ArrayList<>();
+        scottishBankruptOfficerResultList.add(resultEntity);
+
+        ScottishBankruptOfficerSearchResultsEntity searchResultsEntity = new ScottishBankruptOfficerSearchResultsEntity();
+        searchResultsEntity.setItemsPerPage(1);
+        searchResultsEntity.setStartIndex(1);
+        searchResultsEntity.setTotalResults(1);
+        searchResultsEntity.setItems(scottishBankruptOfficerResultList);
+
+        return searchResultsEntity;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
@@ -3,9 +3,6 @@ package uk.gov.companieshouse.bankruptofficersearch.api.request;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +13,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
-import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,24 +24,6 @@ public class OracleQueryDaoImplTest {
 
     private static final String OFFICER_ID = "1234567890";
 
-    private static final String FORENAME_1 = "forename1";
-    private static final String FORENAME_2 = "forename2";
-    private static final String ALIAS = "alias";
-    private static final String SURNAME = "surname";
-    private static final String ADDRESS_LINE_1 = "addressLine1";
-    private static final String ADDRESS_LINE_2 = "addressLine2";
-    private static final String ADDRESS_LINE_3 = "addressLine3";
-    private static final String TOWN = "town";
-    private static final String COUNTY = "county";
-    private static final String POSTCODE = "postcode";
-    private static final LocalDate DATE_OF_BIRTH = LocalDate.now();
-    private static final String CASE_REFERENCE = "caseReference";
-    private static final String CASE_TYPE = "caseType";
-    private static final String BANKRUPTCY_TYPE = "bankruptcyType";
-    private static final LocalDate START_DATE = LocalDate.now();
-    private static final LocalDate DEBTOR_DISCHARGE_DATE = LocalDate.now();
-    private static final LocalDate TRUSTEE_DISCHARGE_DATE = LocalDate.now();
-
     @Mock
     private RestTemplate restTemplate;
 
@@ -56,13 +34,13 @@ public class OracleQueryDaoImplTest {
     private OracleQueryDaoImpl oracleQueryDao;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         ReflectionTestUtils.setField(oracleQueryDao, "oracleQueryApiUrl", ORACLE_QUERY_API_TEST_URL);
     }
 
     @Test
-    public void testGetScottishBankruptOfficers() {
-        ScottishBankruptOfficerSearchResultsEntity searchResults = createSearchResults();
+    void testGetScottishBankruptOfficers() {
+        ScottishBankruptOfficerSearchResultsEntity searchResults = new ScottishBankruptOfficerSearchResultsEntity();
 
         when(restTemplate.postForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI, searchEntity, ScottishBankruptOfficerSearchResultsEntity.class)).thenReturn(searchResults);
 
@@ -72,64 +50,13 @@ public class OracleQueryDaoImplTest {
     }
 
     @Test
-    public void testGetScottishBankruptOfficer() {
-        ScottishBankruptOfficerDetailsEntity expected = createScottishBankruptOfficer();
+    void testGetScottishBankruptOfficer() {
+        ScottishBankruptOfficerDetailsEntity officerDetails = new ScottishBankruptOfficerDetailsEntity();
 
-        when(restTemplate.getForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI + "/" + OFFICER_ID, ScottishBankruptOfficerDetailsEntity.class)).thenReturn(expected);
+        when(restTemplate.getForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI + "/" + OFFICER_ID, ScottishBankruptOfficerDetailsEntity.class)).thenReturn(officerDetails);
 
         ScottishBankruptOfficerDetailsEntity result = oracleQueryDao.getScottishBankruptOfficer(OFFICER_ID);
 
-        assertEquals(expected, result);
-    }
-
-    private ScottishBankruptOfficerDetailsEntity createScottishBankruptOfficer() {
-        ScottishBankruptOfficerDetailsEntity detailsEntity = new ScottishBankruptOfficerDetailsEntity();
-        detailsEntity.setEphemeralKey(OFFICER_ID);
-        detailsEntity.setForename1(FORENAME_1);
-        detailsEntity.setForename2(FORENAME_2);
-        detailsEntity.setAlias(ALIAS);
-        detailsEntity.setSurname(SURNAME);
-        detailsEntity.setAddressLine1(ADDRESS_LINE_1);
-        detailsEntity.setAddressLine2(ADDRESS_LINE_2);
-        detailsEntity.setAddressLine3(ADDRESS_LINE_3);
-        detailsEntity.setTown(TOWN);
-        detailsEntity.setCounty(COUNTY);
-        detailsEntity.setPostcode(POSTCODE);
-        detailsEntity.setDateOfBirth(DATE_OF_BIRTH);
-        detailsEntity.setCaseReference(CASE_REFERENCE);
-        detailsEntity.setCaseType(CASE_TYPE);
-        detailsEntity.setBankruptcyType(BANKRUPTCY_TYPE);
-        detailsEntity.setStartDate(START_DATE);
-        detailsEntity.setDebtorDischargeDate(DEBTOR_DISCHARGE_DATE);
-        detailsEntity.setTrusteeDischargeDate(TRUSTEE_DISCHARGE_DATE);
-
-        return detailsEntity;
-    }
-
-    private ScottishBankruptOfficerSearchResultsEntity createSearchResults() {
-
-        ScottishBankruptOfficerSearchResultEntity resultEntity = new ScottishBankruptOfficerSearchResultEntity();
-        resultEntity.setEphemeralKey(OFFICER_ID);
-        resultEntity.setForename1(FORENAME_1);
-        resultEntity.setForename2(FORENAME_2);
-        resultEntity.setSurname(SURNAME);
-        resultEntity.setAddressLine1(ADDRESS_LINE_1);
-        resultEntity.setAddressLine2(ADDRESS_LINE_2);
-        resultEntity.setAddressLine3(ADDRESS_LINE_3);
-        resultEntity.setTown(TOWN);
-        resultEntity.setCounty(COUNTY);
-        resultEntity.setPostcode(POSTCODE);
-        resultEntity.setDateOfBirth(DATE_OF_BIRTH);
-
-        List<ScottishBankruptOfficerSearchResultEntity> scottishBankruptOfficerResultList = new ArrayList<>();
-        scottishBankruptOfficerResultList.add(resultEntity);
-
-        ScottishBankruptOfficerSearchResultsEntity searchResultsEntity = new ScottishBankruptOfficerSearchResultsEntity();
-        searchResultsEntity.setItemsPerPage(1);
-        searchResultsEntity.setStartIndex(1);
-        searchResultsEntity.setTotalResults(1);
-        searchResultsEntity.setItems(scottishBankruptOfficerResultList);
-
-        return searchResultsEntity;
+        assertEquals(officerDetails, result);
     }
 }


### PR DESCRIPTION
Adding integration layer to oracle-query-api and also adding a GlobalExceptionHandler to catch exceptions for the whole application.

Resolves: [BI-6917](https://companieshouse.atlassian.net/browse/BI-6917)