### PR TITLE
Adding 401 and 500 response codes to spec for the endpoints

### DIFF
--- a/specs/BankruptOfficerSearchAPI
+++ b/specs/BankruptOfficerSearchAPI
@@ -33,6 +33,10 @@ paths:
                 $ref: '#/components/schemas/scottishBankruptOfficerSearchResults'
         '404':
           description: No Scottish bankrupt officers found
+        '401':
+          description: Unauthorised
+        '500':
+          description: Internal server error
   '/internal/officer-search/scottish-bankrupt-officers/{ephemeral_officer_key}':
     parameters:
       - $ref: '#/components/parameters/ephemeralOfficerKey'
@@ -50,6 +54,10 @@ paths:
                 $ref: '#/components/schemas/scottishBankruptOfficer'
         '404':
           description: Scottish bankrupt officer not found
+        '401':
+          description: Unauthorised
+        '500':
+          description: Internal server error
   '/healthcheck':
     get:
       tags:
@@ -61,7 +69,7 @@ paths:
         '200':
           description: OK
         '500':
-          description: Server error
+          description: Internal server error
 components:
   schemas:
     scottishBankruptOfficerSearch:


### PR DESCRIPTION
Adding 401 and 500 response codes to spec for the endpoints:

- `/internal/officer-search/scottish-bankrupt-officers`
- `/internal/officer-search/scottish-bankrupt-officers/{ephemeral_officer_key}`

Resolves: [BI-7143](https://companieshouse.atlassian.net/browse/BI-7143)