### PR TITLE
Modifying oracle query API exception handler and adding Javadocs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerController.java
@@ -21,7 +21,7 @@ public class ScottishBankruptOfficerController {
     private ScottishBankruptOfficerSearchServiceImpl service;
 
     @PostMapping("/internal/officer-search/scottish-bankrupt-officers")
-    public ResponseEntity<ScottishBankruptOfficerSearchResults> searchScottishBankruptOfficers(@RequestBody ScottishBankruptOfficerSearch search) throws ServiceException {
+    public ResponseEntity<ScottishBankruptOfficerSearchResults> searchScottishBankruptOfficers(@RequestBody ScottishBankruptOfficerSearch search) {
         try {
             ScottishBankruptOfficerSearchResults results = service.searchScottishBankruptOfficers(search);
             if (results == null) {
@@ -34,7 +34,7 @@ public class ScottishBankruptOfficerController {
     }
 
     @GetMapping("/internal/officer-search/scottish-bankrupt-officers/{ephemeral_officer_key}")
-    public ResponseEntity<ScottishBankruptOfficerDetails> getOfficerById(@PathVariable("ephemeral_officer_key") String officerId) throws ServiceException {
+    public ResponseEntity<ScottishBankruptOfficerDetails> getOfficerById(@PathVariable("ephemeral_officer_key") String officerId){
         try {
             ScottishBankruptOfficerDetails officer = service.getScottishBankruptOfficer(officerId);
             if (officer == null) {

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.ServiceException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerDetails;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearch;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResults;
@@ -21,20 +21,28 @@ public class ScottishBankruptOfficerController {
     private ScottishBankruptOfficerSearchServiceImpl service;
 
     @PostMapping("/internal/officer-search/scottish-bankrupt-officers")
-    public ResponseEntity<ScottishBankruptOfficerSearchResults> searchScottishBankruptOfficers(@RequestBody ScottishBankruptOfficerSearch search) throws OracleQueryApiException {
-        ScottishBankruptOfficerSearchResults results = service.searchScottishBankruptOfficers(search);
-        if (results == null){
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    public ResponseEntity<ScottishBankruptOfficerSearchResults> searchScottishBankruptOfficers(@RequestBody ScottishBankruptOfficerSearch search) throws ServiceException {
+        try {
+            ScottishBankruptOfficerSearchResults results = service.searchScottishBankruptOfficers(search);
+            if (results == null) {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+            return new ResponseEntity<>(results, HttpStatus.OK);
+        } catch (ServiceException ex) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<>(results, HttpStatus.OK);
     }
 
     @GetMapping("/internal/officer-search/scottish-bankrupt-officers/{ephemeral_officer_key}")
-    public ResponseEntity<ScottishBankruptOfficerDetails> getOfficerById(@PathVariable("ephemeral_officer_key") String officerId) throws OracleQueryApiException {
-        ScottishBankruptOfficerDetails officer = service.getScottishBankruptOfficer(officerId);
-        if (officer == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    public ResponseEntity<ScottishBankruptOfficerDetails> getOfficerById(@PathVariable("ephemeral_officer_key") String officerId) throws ServiceException {
+        try {
+            ScottishBankruptOfficerDetails officer = service.getScottishBankruptOfficer(officerId);
+            if (officer == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            }
+            return ResponseEntity.status(HttpStatus.OK).body(officer);
+        } catch (ServiceException ex) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return ResponseEntity.status(HttpStatus.OK).body(officer);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerDetails;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearch;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResults;
@@ -20,7 +21,7 @@ public class ScottishBankruptOfficerController {
     private ScottishBankruptOfficerSearchServiceImpl service;
 
     @PostMapping("/internal/officer-search/scottish-bankrupt-officers")
-    public ResponseEntity<ScottishBankruptOfficerSearchResults> searchScottishBankruptOfficers(@RequestBody ScottishBankruptOfficerSearch search){
+    public ResponseEntity<ScottishBankruptOfficerSearchResults> searchScottishBankruptOfficers(@RequestBody ScottishBankruptOfficerSearch search) throws OracleQueryApiException {
         ScottishBankruptOfficerSearchResults results = service.searchScottishBankruptOfficers(search);
         if (results == null){
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -29,7 +30,7 @@ public class ScottishBankruptOfficerController {
     }
 
     @GetMapping("/internal/officer-search/scottish-bankrupt-officers/{ephemeral_officer_key}")
-    public ResponseEntity<ScottishBankruptOfficerDetails> getOfficerById(@PathVariable("ephemeral_officer_key") String officerId){
+    public ResponseEntity<ScottishBankruptOfficerDetails> getOfficerById(@PathVariable("ephemeral_officer_key") String officerId) throws OracleQueryApiException {
         ScottishBankruptOfficerDetails officer = service.getScottishBankruptOfficer(officerId);
         if (officer == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
@@ -31,7 +31,8 @@ public class GlobalExceptionHandler {
         HashMap<String, Object> message = new HashMap<>();
         message.put("message", ex.getMessage());
         message.put("error", ex.getClass());
-        LOGGER.error(ex.getMessage(), message);
+        message.put("stack_trace", ex.getStackTrace());
+        LOGGER.error(ex, message);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
@@ -29,9 +29,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Object> handleOracleQueryApiException(OracleQueryApiException ex) {
 
         HashMap<String, Object> message = new HashMap<>();
-        message.put("message", ex.getStatusText());
+        message.put("message", ex.getMessage());
         message.put("error", ex.getClass());
-        message.put("statusCode", ex.getStatusCode());
         LOGGER.error(ex.getMessage(), message);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandler.java
@@ -27,12 +27,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(OracleQueryApiException.class)
     public ResponseEntity<Object> handleOracleQueryApiException(OracleQueryApiException ex) {
-
-        HashMap<String, Object> message = new HashMap<>();
-        message.put("message", ex.getMessage());
-        message.put("error", ex.getClass());
-        message.put("stack_trace", ex.getStackTrace());
-        LOGGER.error(ex, message);
+        LOGGER.error(ex);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/OracleQueryApiException.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/OracleQueryApiException.java
@@ -1,11 +1,8 @@
 package uk.gov.companieshouse.bankruptofficersearch.api.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
+public class OracleQueryApiException extends RuntimeException {
 
-public class OracleQueryApiException extends HttpClientErrorException {
-
-    public OracleQueryApiException(final HttpStatus statusCode, final String statusText) {
-        super(statusCode, statusText);
+    public OracleQueryApiException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/OracleQueryApiException.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/OracleQueryApiException.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.bankruptofficersearch.api.exception;
 
 public class OracleQueryApiException extends RuntimeException {
 
-    public OracleQueryApiException(String message) {
-        super(message);
+    public OracleQueryApiException(String message, Throwable throwable) {
+        super(message, throwable);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/OracleQueryApiException.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/OracleQueryApiException.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.bankruptofficersearch.api.exception;
 
-public class OracleQueryApiException extends RuntimeException {
+public class OracleQueryApiException extends Exception {
 
     public OracleQueryApiException(String message, Throwable throwable) {
         super(message, throwable);

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/ServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/ServiceException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.bankruptofficersearch.api.exception;
+
+public class ServiceException extends Exception {
+
+    public ServiceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/BankruptOfficerDao.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/BankruptOfficerDao.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.bankruptofficersearch.api.request;
 
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
@@ -12,7 +13,7 @@ public interface BankruptOfficerDao {
      * @param search
      * @return searchResultsEntity - matching Scottish bankrupt officers with pagination data
      */
-    ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(ScottishBankruptOfficerSearchEntity search);
+    ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(ScottishBankruptOfficerSearchEntity search) throws OracleQueryApiException;
 
     /**
      * Retrieving details for a bankrupt officer
@@ -20,5 +21,5 @@ public interface BankruptOfficerDao {
      * @param officerId
      * @return officerDetailsEntity - details of a single Scottish bankrupt officer
      */
-    ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(String officerId);
+    ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(String officerId) throws OracleQueryApiException;
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/BankruptOfficerDao.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/BankruptOfficerDao.java
@@ -6,7 +6,19 @@ import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBa
 
 public interface BankruptOfficerDao {
 
+    /**
+     * Retrieving Scottish bankrupt officer search results
+     * 
+     * @param search
+     * @return searchResultsEntity - matching Scottish bankrupt officers with pagination data
+     */
     ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(ScottishBankruptOfficerSearchEntity search);
 
+    /**
+     * Retrieving details for a bankrupt officer
+     *
+     * @param officerId
+     * @return officerDetailsEntity - details of a single Scottish bankrupt officer
+     */
     ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(String officerId);
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
@@ -49,6 +49,7 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
             map.put("status_code", ex.getStatusCode());
 
             if (ex.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+                LOGGER.debug("Oracle query API returned not found", map);
                 return null;
             }
 
@@ -68,10 +69,14 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
         try {
             return restTemplate.getForObject(oracleQueryApiUrl + uri, ScottishBankruptOfficerDetailsEntity.class);
         } catch (HttpClientErrorException ex) {
+            map.put("status_code", ex.getStatusCode());
+
             if (ex.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+                LOGGER.debug("Oracle query API returned not found", map);
                 return null;
             }
 
+            LOGGER.error(ex, map);
             throw new OracleQueryApiException(ex.getMessage(), ex.getCause());
         }
     }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
@@ -50,7 +50,7 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
                 return null;
             }
 
-            throw new OracleQueryApiException(ex.getMessage());
+            throw new OracleQueryApiException(ex.getMessage(), ex.getCause());
         }
     }
 
@@ -69,7 +69,7 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
                 return null;
             }
 
-            throw new OracleQueryApiException(ex.getMessage());
+            throw new OracleQueryApiException(ex.getMessage(), ex.getCause());
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
@@ -50,7 +50,7 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
                 return null;
             }
 
-            throw new OracleQueryApiException(ex.getStatusCode(), ex.getStatusText());
+            throw new OracleQueryApiException(ex.getMessage());
         }
     }
 
@@ -69,7 +69,7 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
                 return null;
             }
 
-            throw new OracleQueryApiException(ex.getStatusCode(), ex.getStatusText());
+            throw new OracleQueryApiException(ex.getMessage());
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImpl.java
@@ -37,7 +37,7 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
     }
 
     @Override
-    public ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(final ScottishBankruptOfficerSearchEntity search) {
+    public ScottishBankruptOfficerSearchResultsEntity getScottishBankruptOfficers(final ScottishBankruptOfficerSearchEntity search) throws OracleQueryApiException {
         HashMap<String, Object> map = new HashMap<>();
         map.put("uri", oracleQueryApiUrl + OFFICERS_URI);
         LOGGER.debug("Calling Oracle Query API to fetch Scottish bankrupt officers", map);
@@ -46,16 +46,19 @@ public class OracleQueryDaoImpl implements BankruptOfficerDao {
             return restTemplate.postForObject(oracleQueryApiUrl + OFFICERS_URI, search,
                 ScottishBankruptOfficerSearchResultsEntity.class);
         } catch (HttpClientErrorException ex) {
+            map.put("status_code", ex.getStatusCode());
+
             if (ex.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
                 return null;
             }
 
+            LOGGER.error(ex, map);
             throw new OracleQueryApiException(ex.getMessage(), ex.getCause());
         }
     }
 
     @Override
-    public ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(final String officerId) {
+    public ScottishBankruptOfficerDetailsEntity getScottishBankruptOfficer(final String officerId) throws OracleQueryApiException {
         String uri = OFFICER_URI.expand(officerId).toString();
 
         HashMap<String, Object> map = new HashMap<>();

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/BankruptOfficerSearchService.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/BankruptOfficerSearchService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.bankruptofficersearch.api.service;
 
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerDetails;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearch;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResults;
@@ -11,13 +12,13 @@ public interface BankruptOfficerSearchService {
      * @param search
      * @return searchResults Matched bankrupt officers + pagination data
      */
-	ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search);
+	ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) throws OracleQueryApiException;
 
     /**
      * Get the details of an bankrupt officer
      * @param ephemeralId
      * @return officerDetails Details for a single officer who is bankrupt
      */
-    ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId);
+    ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) throws OracleQueryApiException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/BankruptOfficerSearchService.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/BankruptOfficerSearchService.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.bankruptofficersearch.api.service;
 
-import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.ServiceException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerDetails;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearch;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResults;
@@ -12,13 +12,13 @@ public interface BankruptOfficerSearchService {
      * @param search
      * @return searchResults Matched bankrupt officers + pagination data
      */
-	ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) throws OracleQueryApiException;
+	ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) throws ServiceException;
 
     /**
      * Get the details of an bankrupt officer
      * @param ephemeralId
      * @return officerDetails Details for a single officer who is bankrupt
      */
-    ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) throws OracleQueryApiException;
+    ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) throws ServiceException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/impl/ScottishBankruptOfficerSearchServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/impl/ScottishBankruptOfficerSearchServiceImpl.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.bankruptofficersearch.api.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
@@ -22,7 +23,7 @@ public class ScottishBankruptOfficerSearchServiceImpl implements BankruptOfficer
     private OracleQueryDaoImpl oracleQueryDao;
 
     @Override
-    public ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) {
+    public ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) throws OracleQueryApiException {
 
         ScottishBankruptOfficerSearchEntity searchEntity = scottishBankruptOfficerTransformer.convertToSearchEntity(
             search);
@@ -36,7 +37,7 @@ public class ScottishBankruptOfficerSearchServiceImpl implements BankruptOfficer
     }
 
     @Override
-    public ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) {
+    public ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) throws OracleQueryApiException {
 
         ScottishBankruptOfficerDetailsEntity officerModel = oracleQueryDao.getScottishBankruptOfficer(ephemeralId);
 

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/impl/ScottishBankruptOfficerSearchServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/service/impl/ScottishBankruptOfficerSearchServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.bankruptofficersearch.api.service.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.ServiceException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
@@ -23,28 +24,33 @@ public class ScottishBankruptOfficerSearchServiceImpl implements BankruptOfficer
     private OracleQueryDaoImpl oracleQueryDao;
 
     @Override
-    public ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) throws OracleQueryApiException {
+    public ScottishBankruptOfficerSearchResults searchScottishBankruptOfficers(ScottishBankruptOfficerSearch search) throws ServiceException {
 
         ScottishBankruptOfficerSearchEntity searchEntity = scottishBankruptOfficerTransformer.convertToSearchEntity(
             search);
-        ScottishBankruptOfficerSearchResultsEntity details = oracleQueryDao.getScottishBankruptOfficers(searchEntity);
 
-        if (details == null) {
-            return null;
+        try {
+            ScottishBankruptOfficerSearchResultsEntity details = oracleQueryDao.getScottishBankruptOfficers(searchEntity);
+            if (details == null) {
+                return null;
+            }
+            return scottishBankruptOfficerTransformer.convertToSearchResults(details);
+        } catch (OracleQueryApiException ex) {
+            throw new ServiceException(ex);
         }
-
-        return scottishBankruptOfficerTransformer.convertToSearchResults(details);
     }
 
     @Override
-    public ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) throws OracleQueryApiException {
+    public ScottishBankruptOfficerDetails getScottishBankruptOfficer(String ephemeralId) throws ServiceException {
 
-        ScottishBankruptOfficerDetailsEntity officerModel = oracleQueryDao.getScottishBankruptOfficer(ephemeralId);
-
-        if (officerModel == null) {
-            return null;
+        try {
+            ScottishBankruptOfficerDetailsEntity officerModel = oracleQueryDao.getScottishBankruptOfficer(ephemeralId);
+            if (officerModel == null) {
+                return null;
+            }
+            return scottishBankruptOfficerTransformer.convertToDetails(officerModel);
+        } catch (OracleQueryApiException ex) {
+            throw new ServiceException(ex);
         }
-
-        return scottishBankruptOfficerTransformer.convertToDetails(officerModel);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/HealthcheckControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/HealthcheckControllerTest.java
@@ -12,14 +12,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(MockitoExtension.class)
-public class HealthcheckControllerTest {
+class HealthcheckControllerTest {
 
     @InjectMocks
     private HealthcheckController controllerUnderTest;
 
     @Test
     @DisplayName("Health check confirms health with HTTP 200")
-    public void applicationHealthcheckRunsSuccessfully(){
+    void applicationHealthcheckRunsSuccessfully(){
         final ResponseEntity<Void> response = controllerUnderTest.getHealthCheck();
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
     }

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerControllerTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerDetails;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearch;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResult;
@@ -33,7 +34,7 @@ class ScottishBankruptOfficerControllerTest {
 
     @Test
     @DisplayName("No officers found")
-    void testNoOfficersFound(){
+    void testNoOfficersFound() throws OracleQueryApiException {
         ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
         when(service.searchScottishBankruptOfficers(search)).thenReturn(null);
 
@@ -44,7 +45,7 @@ class ScottishBankruptOfficerControllerTest {
 
     @Test
     @DisplayName("Officers found")
-    void testOfficersFound(){
+    void testOfficersFound() throws OracleQueryApiException {
         ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
         ScottishBankruptOfficerSearchResults results = new ScottishBankruptOfficerSearchResults();
         ArrayList<ScottishBankruptOfficerSearchResult> officerList = new ArrayList<>();
@@ -64,7 +65,7 @@ class ScottishBankruptOfficerControllerTest {
 
     @Test
     @DisplayName("Officer found by id")
-    void testOfficerFoundById(){
+    void testOfficerFoundById() throws OracleQueryApiException {
         ScottishBankruptOfficerDetails result = new ScottishBankruptOfficerDetails();
 
         when(service.getScottishBankruptOfficer(EPHEMERAL_KEY)).thenReturn(result);
@@ -77,7 +78,7 @@ class ScottishBankruptOfficerControllerTest {
 
     @Test
     @DisplayName("No Officer found by id")
-    void testNoOfficerFoundById(){
+    void testNoOfficerFoundById() throws OracleQueryApiException {
         ScottishBankruptOfficerDetails search = new ScottishBankruptOfficerDetails();
 
         when(service.getScottishBankruptOfficer(search.getEphemeralKey())).thenReturn(null);

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/controller/ScottishBankruptOfficerControllerTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.exception.ServiceException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerDetails;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearch;

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -27,7 +27,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void testHandleOracleQueryApiException() {
-        ResponseEntity<Object> entity = globalExceptionHandler.handleOracleQueryApiException(new OracleQueryApiException("statusText"));
+        ResponseEntity<Object> entity = globalExceptionHandler.handleOracleQueryApiException(new OracleQueryApiException("statusText", new Throwable()));
 
         assertNotNull(entity);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/exception/GlobalExceptionHandlerTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -29,7 +27,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void testHandleOracleQueryApiException() {
-        ResponseEntity<Object> entity = globalExceptionHandler.handleOracleQueryApiException(new OracleQueryApiException(HttpStatus.INTERNAL_SERVER_ERROR, "statusText"));
+        ResponseEntity<Object> entity = globalExceptionHandler.handleOracleQueryApiException(new OracleQueryApiException("statusText"));
 
         assertNotNull(entity);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/interceptor/LoggingInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/interceptor/LoggingInterceptorTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class LoggingInterceptorTest {
+class LoggingInterceptorTest {
 
     @Mock
     private HttpServletRequest httpServletRequest;
@@ -38,20 +38,20 @@ public class LoggingInterceptorTest {
     private LoggingInterceptor loggingInterceptor;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(httpServletRequest.getSession()).thenReturn(session);
     }
 
     @Test
     @DisplayName("Tests the interceptor - preHandle()")
-    public void preHandle() throws JSONException {
+    void preHandle() throws JSONException {
         assertTrue(loggingInterceptor.preHandle(httpServletRequest, httpServletResponse, new Object()));
         verify(session, times(1)).setAttribute(eq(LogContextProperties.START_TIME_KEY.value()), anyLong());
     }
 
     @Test
     @DisplayName("Tests the interceptor - postHandle()")
-    public void postHandle() throws JSONException {
+    void postHandle() throws JSONException {
         long startTime = System.currentTimeMillis();
         when(session.getAttribute(LogContextProperties.START_TIME_KEY.value())).thenReturn(startTime);
         when(httpServletResponse.getStatus()).thenReturn(200);

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/request/OracleQueryDaoImplTest.java
@@ -48,7 +48,7 @@ class OracleQueryDaoImplTest {
     }
 
     @Test
-    void testSearchScottishBankruptOfficers() {
+    void testSearchScottishBankruptOfficers() throws OracleQueryApiException {
         ScottishBankruptOfficerSearchResultsEntity searchResults = new ScottishBankruptOfficerSearchResultsEntity();
 
         when(restTemplate.postForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI, searchEntity, ScottishBankruptOfficerSearchResultsEntity.class)).thenReturn(searchResults);
@@ -59,7 +59,7 @@ class OracleQueryDaoImplTest {
     }
 
     @Test
-    void testSearchScottishBankruptOfficersWhenNoResultsReturned() {
+    void testSearchScottishBankruptOfficersWhenNoResultsReturned() throws OracleQueryApiException {
         when(restTemplate.postForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI, searchEntity, ScottishBankruptOfficerSearchResultsEntity.class)).thenThrow(httpClientErrorException);
         when(httpClientErrorException.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);
 
@@ -77,7 +77,7 @@ class OracleQueryDaoImplTest {
     }
 
     @Test
-    void testGetScottishBankruptOfficer() {
+    void testGetScottishBankruptOfficer() throws OracleQueryApiException {
         ScottishBankruptOfficerDetailsEntity officerDetails = new ScottishBankruptOfficerDetailsEntity();
 
         when(restTemplate.getForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI + "/" + OFFICER_ID, ScottishBankruptOfficerDetailsEntity.class)).thenReturn(officerDetails);
@@ -88,7 +88,7 @@ class OracleQueryDaoImplTest {
     }
 
     @Test
-    void testGetScottishBankruptOfficerWhenOfficerNotFound() {
+    void testGetScottishBankruptOfficerWhenOfficerNotFound() throws OracleQueryApiException {
         when(restTemplate.getForObject(ORACLE_QUERY_API_TEST_URL + OFFICERS_URI + "/" + OFFICER_ID, ScottishBankruptOfficerDetailsEntity.class)).thenThrow(httpClientErrorException);
         when(httpClientErrorException.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);
 

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
@@ -44,7 +45,7 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("Search for bankrupt officers")
-    void testScottishBankruptSearch() {
+    void testScottishBankruptSearch() throws OracleQueryApiException {
         ScottishBankruptOfficerSearchFilters searchFilters = new ScottishBankruptOfficerSearchFilters();
         searchFilters.setForename1(FORENAME);
         searchFilters.setSurname(SURNAME);
@@ -70,7 +71,7 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("No results returned when retrieving Scottish bankrupt officers")
-    void testNoResultsReturnsForScottishBankruptOfficersSearch() {
+    void testNoResultsReturnsForScottishBankruptOfficersSearch() throws OracleQueryApiException {
         ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
         ScottishBankruptOfficerSearchEntity mockTransformerResponse = new ScottishBankruptOfficerSearchEntity();
 
@@ -84,7 +85,7 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("Search for bankrupt officer by id")
-    void testScottishBankruptSearchByID() {
+    void testScottishBankruptSearchByID() throws OracleQueryApiException {
         ScottishBankruptOfficerDetailsEntity detailsEntity = new ScottishBankruptOfficerDetailsEntity();
         ScottishBankruptOfficerDetails details = new ScottishBankruptOfficerDetails();
 
@@ -97,7 +98,7 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("No officer found with get by ID")
-    void testNoOfficerFoundByID() {
+    void testNoOfficerFoundByID() throws OracleQueryApiException {
         when(dao.getScottishBankruptOfficer(EPHEMERAL_KEY)).thenReturn(null);
 
         ScottishBankruptOfficerDetails details = service.getScottishBankruptOfficer(EPHEMERAL_KEY);

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.bankruptofficersearch.api.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.bankruptofficersearch.api.exception.OracleQueryApiException;
+import uk.gov.companieshouse.bankruptofficersearch.api.exception.ServiceException;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerDetailsEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchEntity;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.response.ScottishBankruptOfficerSearchResultsEntity;
@@ -45,7 +48,7 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("Search for bankrupt officers")
-    void testScottishBankruptSearch() throws OracleQueryApiException {
+    void testScottishBankruptSearch() throws OracleQueryApiException, ServiceException {
         ScottishBankruptOfficerSearchFilters searchFilters = new ScottishBankruptOfficerSearchFilters();
         searchFilters.setForename1(FORENAME);
         searchFilters.setSurname(SURNAME);
@@ -71,7 +74,7 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("No results returned when retrieving Scottish bankrupt officers")
-    void testNoResultsReturnsForScottishBankruptOfficersSearch() throws OracleQueryApiException {
+    void testNoResultsReturnsForScottishBankruptOfficersSearch() throws OracleQueryApiException, ServiceException  {
         ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
         ScottishBankruptOfficerSearchEntity mockTransformerResponse = new ScottishBankruptOfficerSearchEntity();
 
@@ -84,8 +87,18 @@ class ScottishBankruptOfficerSearchServiceImplTest {
     }
 
     @Test
-    @DisplayName("Search for bankrupt officer by id")
-    void testScottishBankruptSearchByID() throws OracleQueryApiException {
+    @DisplayName("Scottish bankrupt officers search - throws a ServiceException")
+    void testSearchBankruptOfficersThrowsServiceException() throws OracleQueryApiException {
+        ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
+
+        when(dao.getScottishBankruptOfficers(any())).thenThrow(OracleQueryApiException.class);
+
+        assertThrows(ServiceException.class, () -> service.searchScottishBankruptOfficers(search));
+    }
+
+    @Test
+    @DisplayName("Search for bankrupt officer by ID")
+    void testScottishBankruptSearchByID() throws OracleQueryApiException, ServiceException  {
         ScottishBankruptOfficerDetailsEntity detailsEntity = new ScottishBankruptOfficerDetailsEntity();
         ScottishBankruptOfficerDetails details = new ScottishBankruptOfficerDetails();
 
@@ -98,10 +111,18 @@ class ScottishBankruptOfficerSearchServiceImplTest {
 
     @Test
     @DisplayName("No officer found with get by ID")
-    void testNoOfficerFoundByID() throws OracleQueryApiException {
+    void testNoOfficerFoundByID() throws OracleQueryApiException, ServiceException  {
         when(dao.getScottishBankruptOfficer(EPHEMERAL_KEY)).thenReturn(null);
 
         ScottishBankruptOfficerDetails details = service.getScottishBankruptOfficer(EPHEMERAL_KEY);
         assertNull(details);
+    }
+
+    @Test
+    @DisplayName("Search for bankrupt officer by ID - throws a ServiceException")
+    void testScottishBankruptSearchByIDThrowsServiceException() throws OracleQueryApiException {
+        when(dao.getScottishBankruptOfficer(any())).thenThrow(OracleQueryApiException.class);
+
+        assertThrows(ServiceException.class, () -> service.getScottishBankruptOfficer(EPHEMERAL_KEY));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformerTest.java
@@ -18,7 +18,7 @@ import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankru
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResult;
 import uk.gov.companieshouse.bankruptofficersearch.api.model.rest.ScottishBankruptOfficerSearchResults;
 
-public class ScottishBankruptOfficerTransformerTest {
+class ScottishBankruptOfficerTransformerTest {
 
 
     private ScottishBankruptOfficerTransformer transformer;


### PR DESCRIPTION
Modifying oracle query API exception handler, adding Javadocs and removing the `public` modifier from the test classes to resolve Sonar issues.