### PR TITLE
Feature/BI-11924 add debtor discharge date to scottish search result entity

### DIFF
--- a/specs/BankruptOfficerSearchAPI
+++ b/specs/BankruptOfficerSearchAPI
@@ -147,6 +147,7 @@ components:
         - town
         - county
         - postcode
+        - debtor_discharge_date
       properties:
         ephemeral_officer_key:
           type: string
@@ -183,6 +184,10 @@ components:
         postcode:
           type: string
           description: The postcode for the address.
+        debtor_discharge_date:
+          type: string
+          description: Date the restrictions are lifted from the bankrupt officer.
+          example: '2020-01-01'
     scottishBankruptOfficer:
       allOf:
         - $ref: '#/components/schemas/scottishBankruptOfficerSearchResult'

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
@@ -19,15 +19,6 @@ public class ScottishBankruptOfficerSearchResultEntity {
     private String postcode;
     private LocalDate dateOfBirth;
     private LocalDate debtorDischargeDate;
-    private LocalDate trusteeDischargeDate;
-
-    public LocalDate getTrusteeDischargeDate() {
-        return trusteeDischargeDate;
-    }
-
-    public void setTrusteeDischargeDate(LocalDate trusteeDischargeDate) {
-        this.trusteeDischargeDate = trusteeDischargeDate;
-    }
 
     public String getEphemeralKey() {
         return ephemeralKey;

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
@@ -18,6 +18,16 @@ public class ScottishBankruptOfficerSearchResultEntity {
     private String county;
     private String postcode;
     private LocalDate dateOfBirth;
+    private LocalDate debtorDischargeDate;
+    private LocalDate trusteeDischargeDate;
+
+    public LocalDate getTrusteeDischargeDate() {
+        return trusteeDischargeDate;
+    }
+
+    public void setTrusteeDischargeDate(LocalDate trusteeDischargeDate) {
+        this.trusteeDischargeDate = trusteeDischargeDate;
+    }
 
     public String getEphemeralKey() {
         return ephemeralKey;
@@ -106,4 +116,13 @@ public class ScottishBankruptOfficerSearchResultEntity {
     public void setDateOfBirth(LocalDate dateOfBirth) {
         this.dateOfBirth = dateOfBirth;
     }
+
+    public LocalDate getDebtorDischargeDate() {
+        return debtorDischargeDate;
+    }
+
+    public void setDebtorDischargeDate(LocalDate debtorDischargeDate) {
+        this.debtorDischargeDate = debtorDischargeDate;
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/rest/ScottishBankruptOfficerSearchResult.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/rest/ScottishBankruptOfficerSearchResult.java
@@ -19,6 +19,8 @@ public class ScottishBankruptOfficerSearchResult {
     private String county;
     private String postcode;
     private LocalDate dateOfBirth;
+    private LocalDate debtorDischargeDate;
+
 
     public String getEphemeralKey() {
         return ephemeralKey;
@@ -106,5 +108,13 @@ public class ScottishBankruptOfficerSearchResult {
 
     public void setDateOfBirth(LocalDate dateOfBirth) {
         this.dateOfBirth = dateOfBirth;
+    }
+
+    public LocalDate getDebtorDischargeDate() {
+        return debtorDischargeDate;
+    }
+
+    public void setDebtorDischargeDate(LocalDate debtorDischargeDate) {
+        this.debtorDischargeDate = debtorDischargeDate;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformer.java
@@ -69,6 +69,7 @@ public class ScottishBankruptOfficerTransformer {
         searchResult.setAddressLine3(searchResultEntity.getAddressLine3());
         searchResult.setCounty(searchResultEntity.getCounty());
         searchResult.setTown(searchResultEntity.getTown());
+        searchResult.setDebtorDischargeDate(searchResultEntity.getDebtorDischargeDate());
         return searchResult;
     }
 

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformerTest.java
@@ -67,6 +67,7 @@ class ScottishBankruptOfficerTransformerTest {
         assertEquals(ADDRESS_COUNTY, convertedOfficer.getCounty());
         assertEquals(ADDRESS_POSTCODE, convertedOfficer.getPostcode());
         assertEquals(DATE_OF_BIRTH, convertedOfficer.getDateOfBirth());
+        assertEquals(DEBTOR_DISCHARGE, convertedOfficer.getDebtorDischargeDate());
 
     }
 
@@ -181,6 +182,7 @@ class ScottishBankruptOfficerTransformerTest {
         searchResultEntity.setForename2(FORENAME2);
         searchResultEntity.setSurname(SURNAME);
         searchResultEntity.setDateOfBirth(DATE_OF_BIRTH);
+        searchResultEntity.setDebtorDischargeDate(DEBTOR_DISCHARGE);
         searchResultEntity.setPostcode(ADDRESS_POSTCODE);
         searchResultEntity.setAddressLine1(ADDRESS_LINE1);
         searchResultEntity.setAddressLine2(ADDRESS_LINE2);


### PR DESCRIPTION
Resolves: [BI-11924](https://companieshouse.atlassian.net/browse/BI-11924) 

Add Debtor Discharge Date to ScottishBankruptSearchResultEntity so that it appears in returned results for BankruptOfficers. 