### PR TITLE
Feature/BI-6427 Add officer dob range search filter

### DIFF
--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchFiltersEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchFiltersEntity.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.bankruptofficersearch.api.model.response;
 
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 /**
  * Filters to apply when searching for bankrupt officers
  */
@@ -10,7 +12,8 @@ public class ScottishBankruptOfficerSearchFiltersEntity {
 
     private String forename1;
     private String surname;
-    private String dateOfBirth;
+    private String fromDateOfBirth;
+    private String toDateOfBirth;
     private String postcode;
 
 
@@ -30,12 +33,20 @@ public class ScottishBankruptOfficerSearchFiltersEntity {
         this.surname = surname;
     }
 
-    public String getDateOfBirth() {
-        return dateOfBirth;
+    public String getFromDateOfBirth() {
+        return fromDateOfBirth;
     }
 
-    public void setDateOfBirth(String dateOfBirth) {
-        this.dateOfBirth = dateOfBirth;
+    public void setFromDateOfBirth(String fromDateOfBirth) {
+        this.fromDateOfBirth = fromDateOfBirth;
+    }
+
+    public String getToDateOfBirth() {
+        return toDateOfBirth;
+    }
+
+    public void setToDateOfBirth(String toDateOfBirth) {
+        this.toDateOfBirth = toDateOfBirth;
     }
 
     public String getPostcode() {

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchFiltersEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchFiltersEntity.java
@@ -2,8 +2,6 @@ package uk.gov.companieshouse.bankruptofficersearch.api.model.response;
 
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-
 /**
  * Filters to apply when searching for bankrupt officers
  */

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchFiltersEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchFiltersEntity.java
@@ -32,9 +32,6 @@ public class ScottishBankruptOfficerSearchFiltersEntity {
         this.surname = surname;
     }
 
-    public String getFromDateOfBirth() {
-        return fromDateOfBirth;
-
     public String getAlias() {
         return alias;
     }
@@ -45,7 +42,6 @@ public class ScottishBankruptOfficerSearchFiltersEntity {
 
   public String getFromDateOfBirth() {
         return fromDateOfBirth;
-
     }
 
     public void setFromDateOfBirth(String fromDateOfBirth) {

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.bankruptofficersearch.api.model.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import org.apache.tomcat.jni.Local;
 
 import java.time.LocalDate;
 

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.bankruptofficersearch.api.model.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.tomcat.jni.Local;
+
 import java.time.LocalDate;
 
 @JsonInclude(Include.NON_NULL)

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/rest/ScottishBankruptOfficerSearchFilters.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/rest/ScottishBankruptOfficerSearchFilters.java
@@ -10,7 +10,8 @@ public class ScottishBankruptOfficerSearchFilters {
 
     private String forename1;
     private String surname;
-    private String dateOfBirth;
+    private String fromDateOfBirth;
+    private String toDateOfBirth;
     private String postcode;
 
 
@@ -30,12 +31,20 @@ public class ScottishBankruptOfficerSearchFilters {
         this.surname = surname;
     }
 
-    public String getDateOfBirth() {
-        return dateOfBirth;
+    public String getFromDateOfBirth() {
+        return fromDateOfBirth;
     }
 
-    public void setDateOfBirth(String dateOfBirth) {
-        this.dateOfBirth = dateOfBirth;
+    public void setFromDateOfBirth(String fromDateOfBirth) {
+        this.fromDateOfBirth = fromDateOfBirth;
+    }
+
+    public String getToDateOfBirth() {
+        return toDateOfBirth;
+    }
+
+    public void setToDateOfBirth(String toDateOfBirth) {
+        this.toDateOfBirth = toDateOfBirth;
     }
 
     public String getPostcode() {

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformer.java
@@ -88,7 +88,8 @@ public class ScottishBankruptOfficerTransformer {
 
         filtersEntity.setForename1(filters.getForename1());
         filtersEntity.setSurname(filters.getSurname());
-        filtersEntity.setDateOfBirth(filters.getDateOfBirth());
+        filtersEntity.setFromDateOfBirth(filters.getFromDateOfBirth());
+        filtersEntity.setToDateOfBirth(filters.getToDateOfBirth());
         filtersEntity.setPostcode(filters.getPostcode());
 
         return filtersEntity;

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
@@ -41,10 +41,12 @@ class ScottishBankruptOfficerSearchServiceImplTest {
     private static final int ITEMS_PER_PAGE = 2;
     private static final String FORENAME = "forename";
     private static final String SURNAME = "surname";
-    private static final String FROM_DATE_OF_BIRTH = "2020-01-01";
-    private static final String TO_DATE_OF_BIRTH = "2020-02-02";
+    private static final String DATE_OF_BIRTH = "1975-01-01";
+    private static final String FROM_DATE_OF_BIRTH = "1970-01-01";
+    private static final String TO_DATE_OF_BIRTH = "1980-02-02";
     private static final String POSTCODE = "postcode";
     private static final String EPHEMERAL_KEY = "0123456";
+
 
 
     @Test
@@ -75,18 +77,80 @@ class ScottishBankruptOfficerSearchServiceImplTest {
     }
 
     @Test
-    @DisplayName("No results returned when retrieving Scottish bankrupt officers")
-    void testNoResultsReturnsForScottishBankruptOfficersSearch() throws OracleQueryApiException, ServiceException  {
-        ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
-        ScottishBankruptOfficerSearchEntity mockTransformerResponse = new ScottishBankruptOfficerSearchEntity();
+    @DisplayName("Results returned when searching for Scottish bankrupt officers using DOB range filters")
+    void testResultsReturnsForScottishBankruptOfficersSearchWithDOBFilters() throws OracleQueryApiException, ServiceException  {
+        ScottishBankruptOfficerSearchFilters searchFilters = new ScottishBankruptOfficerSearchFilters();
+        searchFilters.setFromDateOfBirth("1970-01-01");
+        searchFilters.setToDateOfBirth("1980-01-01");
 
-        when(transformer.convertToSearchEntity(search)).thenReturn(mockTransformerResponse);
-        when(dao.getScottishBankruptOfficers(mockTransformerResponse)).thenReturn(null);
+        ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
+        search.setStartIndex(START_INDEX);
+        search.setItemsPerPage(ITEMS_PER_PAGE);
+        search.setFilters(searchFilters);
+
+        ScottishBankruptOfficerSearchEntity searchEntity = new ScottishBankruptOfficerSearchEntity();
+        ScottishBankruptOfficerSearchResultsEntity resultsEntity = new ScottishBankruptOfficerSearchResultsEntity();
+        ScottishBankruptOfficerSearchResults expectedSearchResults = new ScottishBankruptOfficerSearchResults();
+
+        when(transformer.convertToSearchEntity(search)).thenReturn(searchEntity);
+        when(dao.getScottishBankruptOfficers(searchEntity)).thenReturn(resultsEntity);
+        when(transformer.convertToSearchResults(resultsEntity)).thenReturn(expectedSearchResults);
 
         ScottishBankruptOfficerSearchResults searchResults = service.searchScottishBankruptOfficers(search);
-
-        assertNull(searchResults);
+        assertEquals(expectedSearchResults, searchResults);
     }
+
+
+    @Test
+    @DisplayName("Results returned when searching for Scottish bankrupt officers using From DOB filters")
+    void testResultsReturnsForScottishBankruptOfficersSearchWithFromFilters() throws OracleQueryApiException, ServiceException  {
+        ScottishBankruptOfficerSearchFilters searchFilters = new ScottishBankruptOfficerSearchFilters();
+
+        searchFilters.setFromDateOfBirth(FROM_DATE_OF_BIRTH);
+        ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
+        search.setStartIndex(START_INDEX);
+        search.setItemsPerPage(ITEMS_PER_PAGE);
+        search.setFilters(searchFilters);
+
+
+        ScottishBankruptOfficerSearchEntity searchEntity = new ScottishBankruptOfficerSearchEntity();
+        ScottishBankruptOfficerSearchResultsEntity resultsEntity = new ScottishBankruptOfficerSearchResultsEntity();
+        ScottishBankruptOfficerSearchResults expectedSearchResults = new ScottishBankruptOfficerSearchResults();
+
+        when(transformer.convertToSearchEntity(search)).thenReturn(searchEntity);
+        when(dao.getScottishBankruptOfficers(searchEntity)).thenReturn(resultsEntity);
+        when(transformer.convertToSearchResults(resultsEntity)).thenReturn(expectedSearchResults);
+
+
+
+        ScottishBankruptOfficerSearchResults searchResults = service.searchScottishBankruptOfficers(search);
+        assertEquals(expectedSearchResults, searchResults);
+    }
+
+    @Test
+    @DisplayName("Results returned when searching for Scottish bankrupt officers using To DOB filters")
+    void testResultsReturnsForScottishBankruptOfficersSearchWithToFilters() throws OracleQueryApiException, ServiceException  {
+        ScottishBankruptOfficerSearchFilters searchFilters = new ScottishBankruptOfficerSearchFilters();
+
+        searchFilters.setToDateOfBirth(TO_DATE_OF_BIRTH);
+        ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();
+        search.setStartIndex(START_INDEX);
+        search.setItemsPerPage(ITEMS_PER_PAGE);
+        search.setFilters(searchFilters);
+
+
+        ScottishBankruptOfficerSearchEntity searchEntity = new ScottishBankruptOfficerSearchEntity();
+        ScottishBankruptOfficerSearchResultsEntity resultsEntity = new ScottishBankruptOfficerSearchResultsEntity();
+        ScottishBankruptOfficerSearchResults expectedSearchResults = new ScottishBankruptOfficerSearchResults();
+
+        when(transformer.convertToSearchEntity(search)).thenReturn(searchEntity);
+        when(dao.getScottishBankruptOfficers(searchEntity)).thenReturn(resultsEntity);
+        when(transformer.convertToSearchResults(resultsEntity)).thenReturn(expectedSearchResults);
+
+        ScottishBankruptOfficerSearchResults searchResults = service.searchScottishBankruptOfficers(search);
+        assertEquals(expectedSearchResults, searchResults);
+    }
+
 
     @Test
     @DisplayName("Scottish bankrupt officers search - throws a ServiceException")

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/service/ScottishBankruptOfficerSearchServiceImplTest.java
@@ -41,7 +41,8 @@ class ScottishBankruptOfficerSearchServiceImplTest {
     private static final int ITEMS_PER_PAGE = 2;
     private static final String FORENAME = "forename";
     private static final String SURNAME = "surname";
-    private static final String DATE_OF_BIRTH = "2020-01-01";
+    private static final String FROM_DATE_OF_BIRTH = "2020-01-01";
+    private static final String TO_DATE_OF_BIRTH = "2020-02-02";
     private static final String POSTCODE = "postcode";
     private static final String EPHEMERAL_KEY = "0123456";
 
@@ -52,7 +53,8 @@ class ScottishBankruptOfficerSearchServiceImplTest {
         ScottishBankruptOfficerSearchFilters searchFilters = new ScottishBankruptOfficerSearchFilters();
         searchFilters.setForename1(FORENAME);
         searchFilters.setSurname(SURNAME);
-        searchFilters.setDateOfBirth(DATE_OF_BIRTH);
+        searchFilters.setFromDateOfBirth(FROM_DATE_OF_BIRTH);
+        searchFilters.setToDateOfBirth(TO_DATE_OF_BIRTH);
         searchFilters.setPostcode(POSTCODE);
 
         ScottishBankruptOfficerSearch search = new ScottishBankruptOfficerSearch();

--- a/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformerTest.java
@@ -41,6 +41,8 @@ class ScottishBankruptOfficerTransformerTest {
     private static final LocalDate DEBTOR_DISCHARGE = LocalDate.now();
     private static final LocalDate TRUSTEE_DISCHARGE_DATE = LocalDate.now();
     private static final LocalDate DATE_OF_BIRTH = LocalDate.now();
+    private static final LocalDate FROM_DATE_OF_BIRTH = LocalDate.now();
+    private static final LocalDate TO_DATE_OF_BIRTH = LocalDate.now();
     private static final int START_INDEX = 0;
     private static final int ITEMS_PER_PAGE = 0;
 
@@ -130,7 +132,8 @@ class ScottishBankruptOfficerTransformerTest {
         ScottishBankruptOfficerSearchFilters filters = new ScottishBankruptOfficerSearchFilters();
         filters.setForename1(FORENAME1);
         filters.setSurname(SURNAME);
-        filters.setDateOfBirth(DATE_OF_BIRTH.toString());
+        filters.setFromDateOfBirth(FROM_DATE_OF_BIRTH.toString());
+        filters.setToDateOfBirth(TO_DATE_OF_BIRTH.toString());
         filters.setPostcode(ADDRESS_POSTCODE);
 
         scottishBankruptOfficerSearch.setFilters(filters);
@@ -142,7 +145,8 @@ class ScottishBankruptOfficerTransformerTest {
         assertEquals(ITEMS_PER_PAGE, convertedOfficer.getItemsPerPage());
         assertEquals(filters.getForename1(), convertedOfficer.getFilters().getForename1());
         assertEquals(filters.getSurname(), convertedOfficer.getFilters().getSurname());
-        assertEquals(filters.getDateOfBirth(), convertedOfficer.getFilters().getDateOfBirth());
+        assertEquals(filters.getFromDateOfBirth(), convertedOfficer.getFilters().getFromDateOfBirth());
+        assertEquals(filters.getToDateOfBirth(), convertedOfficer.getFilters().getToDateOfBirth());
         assertEquals(filters.getPostcode(), convertedOfficer.getFilters().getPostcode());
     }
 


### PR DESCRIPTION
Resolves: [BI-6427](https://companieshouse.atlassian.net/browse/BI-6427)

- Adding toDateOfBirth and FromDateOfBirth as filters to the Scottish Bankrupt office search to allow for a range of dobs of officers to be returned
- Updating unit tests to support new filters