### PR TITLE
BI-12027-add case type field to search results entities and transformer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/response/ScottishBankruptOfficerSearchResultEntity.java
@@ -20,6 +20,8 @@ public class ScottishBankruptOfficerSearchResultEntity {
     private String postcode;
     private LocalDate dateOfBirth;
     private LocalDate debtorDischargeDate;
+    private String caseType;
+
 
     public String getEphemeralKey() {
         return ephemeralKey;
@@ -115,6 +117,13 @@ public class ScottishBankruptOfficerSearchResultEntity {
 
     public void setDebtorDischargeDate(LocalDate debtorDischargeDate) {
         this.debtorDischargeDate = debtorDischargeDate;
+    }
+    public String getCaseType() {
+        return caseType;
+    }
+
+    public void setCaseType(String caseType) {
+        this.caseType = caseType;
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/rest/ScottishBankruptOfficerSearchResult.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/model/rest/ScottishBankruptOfficerSearchResult.java
@@ -20,7 +20,7 @@ public class ScottishBankruptOfficerSearchResult {
     private String postcode;
     private LocalDate dateOfBirth;
     private LocalDate debtorDischargeDate;
-
+    private String caseType;
 
     public String getEphemeralKey() {
         return ephemeralKey;
@@ -116,5 +116,13 @@ public class ScottishBankruptOfficerSearchResult {
 
     public void setDebtorDischargeDate(LocalDate debtorDischargeDate) {
         this.debtorDischargeDate = debtorDischargeDate;
+    }
+
+    public String getCaseType() {
+        return caseType;
+    }
+
+    public void setCaseType(String caseType) {
+        this.caseType = caseType;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/bankruptofficersearch/api/transformer/ScottishBankruptOfficerTransformer.java
@@ -70,6 +70,7 @@ public class ScottishBankruptOfficerTransformer {
         searchResult.setCounty(searchResultEntity.getCounty());
         searchResult.setTown(searchResultEntity.getTown());
         searchResult.setDebtorDischargeDate(searchResultEntity.getDebtorDischargeDate());
+        searchResult.setCaseType(searchResultEntity.getCaseType());
         return searchResult;
     }
 


### PR DESCRIPTION
Resolves [BI-12027](https://companieshouse.atlassian.net/browse/BI-12027)

- Add case type field to search results entity classes and transformer so that field can be displayed in BADOS officer search result page 