### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,12 @@
 artifact_name       := bankrupt-officer-search-api
 version             := unversioned
-##### Start of variable block for top of Makfile
+
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
-dependency_check_suppressions_repo_branch:=feature/suppressions-for-company-accounts-api
-
+dependency_check_suppressions_repo_branch:=main
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
 suppressions_file := target/suppressions.xml
-##### End of variable block
 
 .PHONY: clean
 clean:
@@ -67,7 +59,6 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
 
-##### Start of dependency-check block to be put at bottom of Makefile
 .PHONY: dependency-check
 dependency-check:
 	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
@@ -91,7 +82,7 @@ dependency-check:
 	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
 	if [  -f "$${suppressions_path}" ]; then \
 		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
 	else \
 		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
 		exit 1; \
@@ -100,4 +91,3 @@ dependency-check:
 .PHONY: security-check
 security-check: dependency-check
 
-##### End of dependency-check block

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.11</version>
+        <relativePath/>
     </parent>
     <artifactId>bankrupt-officer-search-api</artifactId>
     <version>unversioned</version>


### PR DESCRIPTION
b4c5c47 Update parent pom to 2.1.11, use relativePath
All parent pom references use relativePath.
2.1.11 brings in latest correct dependency-check settings.

1d21536 Tidy, repoint at dep-check-suppressions/main
The 'dependency-check' target uses a variable
dependency_check_suppressions_repo_branch
which previously pointed to a different branch:
feature/suppressions-for-company-accounts-api
... but that branch has been merged into main and so this variable
should now point to main.
Tidy Makefile for dependency-check consistency
Make line spacing, ordering, format for dependency-check sections
identical across Makefiles.
Add json to dependency check report formats.

Fixes [CC-1732](https://companieshouse.atlassian.net/browse/CC-1732)

[CC-1732]: https://companieshouse.atlassian.net/browse/CC-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ